### PR TITLE
Create Product-of-Array-Except-Self.py

### DIFF
--- a/Product-of-Array-Except-Self.py
+++ b/Product-of-Array-Except-Self.py
@@ -1,0 +1,30 @@
+# this is leet code problem solution (238)
+
+def productExceptSelf(nums):
+    n = len(nums)
+    prefix_product = [1] * n
+    suffix_product = [1] * n
+    result = [0] * n
+
+    # Calculate prefix products
+    prefix = 1
+    for i in range(n):
+        prefix_product[i] = prefix
+        prefix *= nums[i]
+
+    # Calculate suffix products
+    suffix = 1
+    for i in range(n - 1, -1, -1):
+        suffix_product[i] = suffix
+        suffix *= nums[i]
+
+    # Calculate result
+    for i in range(n):
+        result[i] = prefix_product[i] * suffix_product[i]
+
+    return result
+
+# Example usage:
+nums = [1, 2, 3, 4]
+result = productExceptSelf(nums)
+print(result)  # Output: [24, 12, 8, 6]


### PR DESCRIPTION
# An alternative approach to solving the problem of finding an array where each element is the product of all elements in the original array except itself is to use two passes, each with a single array for prefix and suffix products, to save space and still achieve O(n) time complexity
# here is the code

def productExceptSelf(nums):
    n = len(nums)
    result = [1] * n

    # First pass: Calculate prefix products and store in the result array
    prefix_product = 1
    for i in range(n):
        result[i] *= prefix_product
        prefix_product *= nums[i]

    # Second pass: Calculate suffix products and multiply with the result array
    suffix_product = 1
    for i in range(n - 1, -1, -1):
        result[i] *= suffix_product
        suffix_product *= nums[i]

    return result

# Example usage:
nums = [1, 2, 3, 4]
result = productExceptSelf(nums)
print(result)  # Output: [24, 12, 8, 6]
